### PR TITLE
:pencil: Removes placeholder text from description

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,7 +6,7 @@ title: DjangoCon US
 bio:
 
 # twitter summary info
-description: "DjangoCon US description here"
+description: "DjangoCon US"
 
 favicon: https://fav.farm/🎪
 


### PR DESCRIPTION
Removes  what looks like placeholder text in the description metadata

![image](https://github.com/djangocon/djangocon.us/assets/1726961/e014cb03-e996-41a0-a443-ee9bfe408594)
